### PR TITLE
修正用

### DIFF
--- a/app/src/main/java/com/example/apptask/FormDialog.kt
+++ b/app/src/main/java/com/example/apptask/FormDialog.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.VisualTransformation
@@ -39,7 +40,7 @@ import androidx.compose.ui.window.Dialog
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ShowFormDialog(setShowDialog: (Boolean) -> Unit) {
+fun FormDialog(setShowDialog: (Boolean) -> Unit) {
     Dialog(onDismissRequest = { setShowDialog(false) }) {
         Surface {
             Column(
@@ -51,7 +52,7 @@ fun ShowFormDialog(setShowDialog: (Boolean) -> Unit) {
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
                     Text(
-                        text = "アイテムを追加",
+                        text = stringResource(R.string.form_title),
                         style = TextStyle(fontWeight = FontWeight.Bold)
                     )
                     Icon(
@@ -66,7 +67,7 @@ fun ShowFormDialog(setShowDialog: (Boolean) -> Unit) {
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     var quantity by rememberSaveable { mutableIntStateOf(min) }
-                    Text(text = "数量：${"%,d".format(quantity)}")
+                    Text(text = stringResource(R.string.form_quantity) + "%,d".format(quantity))
                     Spacer(modifier = Modifier.weight(1f))
                     ElevatedButton(
                         onClick = { quantity ++ },
@@ -91,12 +92,13 @@ fun ShowFormDialog(setShowDialog: (Boolean) -> Unit) {
                     horizontalArrangement = Arrangement.spacedBy(5.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
+                    val clockFormat = "hh:mm:ss"
                     val isDarkTheme = isSystemInDarkTheme()
                     AndroidView(
                         factory = { context ->
                             TextClock(context).apply {
-                                format12Hour?.let { this.format12Hour = "hh:mm:ss" }
-                                format24Hour?.let { this.format24Hour = "hh:mm:ss" }
+                                format12Hour?.let { this.format12Hour = clockFormat }
+                                format24Hour?.let { this.format24Hour = clockFormat }
                                 timeZone?.let {this.timeZone = null}
                                 if (isDarkTheme) {
                                     setTextColor(context.getColor(R.color.white))
@@ -126,7 +128,7 @@ fun ShowFormDialog(setShowDialog: (Boolean) -> Unit) {
                                 ),
                                 placeholder = {
                                     Text(
-                                        text = "コメントを入力",
+                                        text = stringResource(R.string.form_placeHolder),
                                         style = TextStyle(color = Color.Gray)
                                     )
                                 }
@@ -139,7 +141,7 @@ fun ShowFormDialog(setShowDialog: (Boolean) -> Unit) {
                     horizontalArrangement = Arrangement.Center
                 ) {
                     Button(onClick = { setShowDialog(false) }) {
-                        Text(text = "追加")
+                        Text(text = stringResource(R.string.form_addButton))
                     }
                 }
             }

--- a/app/src/main/java/com/example/apptask/FormDialog.kt
+++ b/app/src/main/java/com/example/apptask/FormDialog.kt
@@ -66,13 +66,13 @@ fun FormDialog(setShowDialog: (Boolean) -> Unit) {
                     horizontalArrangement = Arrangement.spacedBy(5.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    var quantity by rememberSaveable { mutableIntStateOf(min) }
+                    var quantity by rememberSaveable { mutableIntStateOf(Constants.STOCK_QUANTITY_MIN) }
                     Text(text = stringResource(R.string.form_quantity) + "%,d".format(quantity))
                     Spacer(modifier = Modifier.weight(1f))
                     ElevatedButton(
                         onClick = { quantity ++ },
                         enabled = when(quantity) {
-                            max -> false
+                            Constants.STOCK_QUANTITY_MAX -> false
                             else -> true
                         }
                     ) {
@@ -81,7 +81,7 @@ fun FormDialog(setShowDialog: (Boolean) -> Unit) {
                     ElevatedButton(
                         onClick = { quantity -- },
                         enabled = when(quantity) {
-                            min -> false
+                            Constants.STOCK_QUANTITY_MIN -> false
                             else -> true
                         }
                     ) {
@@ -92,14 +92,13 @@ fun FormDialog(setShowDialog: (Boolean) -> Unit) {
                     horizontalArrangement = Arrangement.spacedBy(5.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    val clockFormat = "hh:mm:ss"
                     val isDarkTheme = isSystemInDarkTheme()
                     AndroidView(
                         factory = { context ->
                             TextClock(context).apply {
-                                format12Hour?.let { this.format12Hour = clockFormat }
-                                format24Hour?.let { this.format24Hour = clockFormat }
-                                timeZone?.let {this.timeZone = null}
+                                format12Hour?.let { this.format12Hour = Constants.CLOCK_FORMAT }
+                                format24Hour?.let { this.format24Hour = Constants.CLOCK_FORMAT }
+                                timeZone?.let { this.timeZone = null }
                                 if (isDarkTheme) {
                                     setTextColor(context.getColor(R.color.white))
                                 }

--- a/app/src/main/java/com/example/apptask/FormDialog.kt
+++ b/app/src/main/java/com/example/apptask/FormDialog.kt
@@ -1,0 +1,148 @@
+package com.example.apptask
+
+import android.widget.TextClock
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ShowFormDialog(setShowDialog: (Boolean) -> Unit) {
+    Dialog(onDismissRequest = { setShowDialog(false) }) {
+        Surface {
+            Column(
+                modifier = Modifier.padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = "アイテムを追加",
+                        style = TextStyle(fontWeight = FontWeight.Bold)
+                    )
+                    Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = null,
+                        tint = colorResource(android.R.color.darker_gray),
+                        modifier = Modifier.clickable { setShowDialog(false) }
+                    )
+                }
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(5.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    var quantity by rememberSaveable { mutableIntStateOf(min) }
+                    Text(text = "数量：${"%,d".format(quantity)}")
+                    Spacer(modifier = Modifier.weight(1f))
+                    ElevatedButton(
+                        onClick = { quantity ++ },
+                        enabled = when(quantity) {
+                            max -> false
+                            else -> true
+                        }
+                    ) {
+                        Text(text = "+")
+                    }
+                    ElevatedButton(
+                        onClick = { quantity -- },
+                        enabled = when(quantity) {
+                            min -> false
+                            else -> true
+                        }
+                    ) {
+                        Text(text = "-")
+                    }
+                }
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(5.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    val isDarkTheme = isSystemInDarkTheme()
+                    AndroidView(
+                        factory = { context ->
+                            TextClock(context).apply {
+                                format12Hour?.let { this.format12Hour = "hh:mm:ss" }
+                                format24Hour?.let { this.format24Hour = "hh:mm:ss" }
+                                timeZone?.let {this.timeZone = null}
+                                if (isDarkTheme) {
+                                    setTextColor(context.getColor(R.color.white))
+                                }
+                            }
+                        }
+                    )
+                    var comment by rememberSaveable { mutableStateOf("") }
+                    BasicTextField(
+                        modifier = Modifier.weight(1f),
+                        value = comment,
+                        onValueChange = { comment = it },
+                        singleLine = true,
+                        decorationBox = @Composable { innerTextField ->
+                            TextFieldDefaults.DecorationBox(
+                                value = comment,
+                                innerTextField = innerTextField,
+                                enabled = true,
+                                singleLine = true,
+                                visualTransformation = VisualTransformation.None,
+                                interactionSource = MutableInteractionSource(),
+                                contentPadding = TextFieldDefaults.contentPaddingWithLabel(
+                                    start = 0.dp,
+                                    top = 0.dp,
+                                    end = 0.dp,
+                                    bottom = 0.dp
+                                ),
+                                placeholder = {
+                                    Text(
+                                        text = "コメントを入力",
+                                        style = TextStyle(color = Color.Gray)
+                                    )
+                                }
+                            )
+                        }
+                    )
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    Button(onClick = { setShowDialog(false) }) {
+                        Text(text = "追加")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/apptask/MainActivity.kt
+++ b/app/src/main/java/com/example/apptask/MainActivity.kt
@@ -1,69 +1,40 @@
 package com.example.apptask
 
 import android.content.res.Configuration
-import android.os.Build
 import android.os.Bundle
-import android.util.TypedValue
-import android.widget.TextClock
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.annotation.RequiresApi
-import androidx.compose.foundation.background
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Checkbox
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults.topAppBarColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.input.VisualTransformation
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
 import com.example.apptask.ui.theme.AppTaskTheme
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 class MainActivity : ComponentActivity() {
-    @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            Column {
-                CreateForm()
-                CreateList(StockData.stockList)
+            AppTaskTheme {
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    ShowHome()
+                }
             }
         }
     }
@@ -72,367 +43,57 @@ class MainActivity : ComponentActivity() {
 @Preview(
     uiMode = Configuration.UI_MODE_NIGHT_NO,
     showBackground = true,
-    name = "light Mode"
+    fontScale = 1f,
+    name = "Light Mode"
 )
-/*
 @Preview(
     uiMode = Configuration.UI_MODE_NIGHT_YES,
     showBackground = true,
+    fontScale = 1f,
     name = "Dark Mode"
 )
-*/
-@RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun QuantityPreview() {
+fun Preview() {
     AppTaskTheme {
-        Surface {
-            Column(modifier = Modifier.fillMaxHeight()) {
-                CreateForm()
-                CreateList(StockData.stockList)
-            }
+        Surface(modifier = Modifier.fillMaxSize()) {
+            ShowHome()
         }
     }
 }
 
-data class Stock(val clock: String, val quantity: Int, val comment: String)
-const val max = 9999
 const val min = 0
+const val max = 9999
+
+data class StockData(val whenAdded: String, val quantity: Int, val comment: String)
 
 @OptIn(ExperimentalMaterial3Api::class)
-@RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun CreateForm() {
-    Column(
-        modifier = Modifier
-            .padding(all = 8.dp)
-            .fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(5.dp)
-    ) {
-        var quantity by rememberSaveable { mutableIntStateOf(min) }
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ){
-            // 数量
-            Text(
-                text = "数量：${"%,d".format(quantity)}",  // カンマ付き表示
-                fontSize = with(LocalDensity.current) { 30.dp.toSp() }
-            )
-            Spacer(modifier = Modifier.weight(1f))
-            // プラスボタン
-            Button(
-                onClick = { quantity ++ },
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = Color.LightGray,
-                    contentColor = Color.Black,
-                    disabledContainerColor = Color.LightGray,
-                    disabledContentColor = Color.Gray
+fun ShowHome() {
+    var showDialog by rememberSaveable { mutableStateOf(true) }
+    if (showDialog)
+        ShowFormDialog(setShowDialog = { showDialog = it })
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                colors = topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.primary,
                 ),
-                modifier = Modifier.size(width = 50.dp, height = 45.dp),
-                shape = RoundedCornerShape(3.dp),
-                contentPadding = PaddingValues(0.dp),
-                enabled = when(quantity) {
-                    max -> false
-                    else -> true
+                title = {
+                    Text(text = "Home")
                 }
-            ) {
-                Text(
-                    text = "＋",
-                    fontSize = with(LocalDensity.current) { 15.dp.toSp() }
-                )
-            }
-            // マイナスボタン
-            Button(
-                onClick = { quantity -- },
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = Color.LightGray,
-                    contentColor = Color.Black,
-                    disabledContainerColor = Color.LightGray,
-                    disabledContentColor = Color.Gray
-                ),
-                modifier = Modifier.size(width = 50.dp, height = 45.dp),
-                shape = RoundedCornerShape(3.dp),
-                contentPadding = PaddingValues(0.dp),
-                enabled = when(quantity) {
-                    min -> false
-                    else -> true
-                }
-            ) {
-                Text(
-                    text = "－",
-                    fontSize = with(LocalDensity.current) { 15.dp.toSp() }
-                )
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showDialog = true }) {
+                Icon(Icons.Default.Add, "Floating action button")
             }
         }
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier.padding(innerPadding)
         ) {
-            // 時刻
-            val darkTheme: Boolean = isSystemInDarkTheme()
-            AndroidView(
-                factory = { context ->
-                    TextClock(context).apply {
-                        format12Hour?.let { this.format12Hour = "hh:mm:ss" }
-                        format24Hour?.let { this.format24Hour = "hh:mm:ss" }
-                        timeZone?.let { this.timeZone = null }
-                        textSize.let { this.setTextSize(TypedValue.COMPLEX_UNIT_DIP,20f) }
-                        if (darkTheme) {
-                            setTextColor(context.getColor(R.color.white))
-                        } else {
-                            setTextColor(context.getColor(R.color.black))
-                        }
-                    }
-                }
-            )
-            // コメント入力欄
-            val focusManager = LocalFocusManager.current
-            var comment by rememberSaveable { mutableStateOf("") }
-            BasicTextField(
-                value = comment,
-                modifier = Modifier.weight(1f),
-                onValueChange = { comment = it },
-                singleLine = true,
-                textStyle = TextStyle(fontSize = with(LocalDensity.current) { 20.dp.toSp() }),
-                decorationBox = @Composable { innerTextField ->
-                    TextFieldDefaults.DecorationBox(
-                        value = comment,
-                        innerTextField = innerTextField,
-                        enabled = true,
-                        singleLine = true,
-                        visualTransformation = VisualTransformation.None,
-                        interactionSource = MutableInteractionSource(),
-                        contentPadding = TextFieldDefaults.contentPaddingWithLabel(
-                            start = 0.dp,
-                            top = 0.dp,
-                            end = 0.dp,
-                            bottom = 0.dp,
-                        ),
-                        placeholder = {
-                            Text(
-                                text = "コメントを入力",
-                                color = Color.Gray,
-                                fontSize = with(LocalDensity.current) { 15.dp.toSp() }
-                            )
-                        }
-                    )
-                }
-            )
-            // 追加ボタン
-            Button(
-                onClick = {
-                    val formatTime = DateTimeFormatter.ofPattern("HH:mm:ss")
-                    val currentTime = formatTime.format(LocalDateTime.now())
-                    focusManager.clearFocus()
-                    StockData.stockList += Stock(
-                        clock = currentTime,
-                        quantity = quantity,
-                        comment = comment
-                    )
-                    quantity = 0
-                    comment = ""
-                },
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = Color.LightGray,
-                    contentColor = Color.Black,
-                    disabledContainerColor = Color.LightGray,
-                    disabledContentColor = Color.Gray
-                ),
-                modifier = Modifier.size(width = 50.dp, height = 30.dp),
-                shape = RoundedCornerShape(3.dp),
-                contentPadding = PaddingValues(0.dp),
-                enabled = comment.isNotEmpty()
-            ) {
-                Text(
-                    text = "追加",
-                    fontSize = with(LocalDensity.current) { 15.dp.toSp() }
-                )
-            }
+            ShowStockList()
         }
     }
-}
-
-@Composable
-fun StockCard(ind: Int, stc: Stock) {
-    var isChecked by rememberSaveable { mutableStateOf(false) }
-    var cardColor = Color(0xFFFFFBFE)
-    if (isChecked) {
-        cardColor = Color(0xFF00ff00)
-    } else if (ind % 2 == 0) {
-        cardColor = Color(0xFFe6e6fa)
-    }
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(color = cardColor)
-    ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 5.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            Checkbox(
-                modifier = Modifier.size(15.dp),
-                checked = isChecked,
-                onCheckedChange = { isChecked = !isChecked }
-            )
-            // 時刻
-            Text(
-                text = stc.clock,
-                overflow = TextOverflow.Ellipsis,
-                fontSize = with(LocalDensity.current) { 15.dp.toSp() }
-            )
-            // 数量
-            Box(
-                modifier = Modifier.size(width = 40.dp, height = 20.dp),
-                contentAlignment = Alignment.CenterEnd
-            ){
-                Text(
-                    text = "%,d".format(stc.quantity),
-                    overflow = TextOverflow.Ellipsis,
-                    fontSize = with(LocalDensity.current) { 15.dp.toSp() }
-                )
-            }
-            // コメント
-            if (stc.comment.isEmpty()) {
-                Text(
-                    text = "コメント無し",
-                    color = Color.LightGray,
-                    modifier = Modifier.weight(1f),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    fontSize = with(LocalDensity.current) { 15.dp.toSp() }
-                )
-            } else {
-                Text(
-                    text = stc.comment,
-                    modifier = Modifier.weight(1f),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,    // 長いコメントは省略
-                    fontSize = with(LocalDensity.current) { 15.dp.toSp() }
-                )
-            }
-            // 削除ボタン
-            Button(
-                onClick = {
-                    StockData.stockList.removeAt(ind)
-                },
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = Color.LightGray,
-                    contentColor = Color.Black,
-                    disabledContainerColor = Color.LightGray,
-                    disabledContentColor = Color.Gray
-                ),
-                modifier = Modifier.size(width = 50.dp, height = 30.dp),
-                shape = RoundedCornerShape(3.dp),
-                contentPadding = PaddingValues(0.dp)
-            ) {
-                Text(
-                    text = "削除",
-                    fontSize = with(LocalDensity.current) { 15.dp.toSp() }
-                )
-            }
-        }
-    }
-}
-
-@Composable
-fun CreateList(stocks: List<Stock>) {
-    LazyColumn {
-        itemsIndexed(stocks) { index, stock ->
-            StockCard(index, stock)
-        }
-    }
-    var alertDialog by rememberSaveable { mutableStateOf(false) }
-    var sumDialog by rememberSaveable { mutableStateOf(false) }
-    Row(
-        modifier = Modifier
-            .padding(all = 8.dp)
-            .fillMaxWidth(),
-        verticalAlignment = Alignment.Bottom,
-        horizontalArrangement = Arrangement.spacedBy(5.dp, Alignment.End)
-    ) {
-        // クリアボタン
-        Button(
-            onClick = {
-                alertDialog = true
-            },
-            colors = ButtonDefaults.buttonColors(
-                containerColor = Color.LightGray,
-                contentColor = Color.Black,
-                disabledContainerColor = Color.LightGray,
-                disabledContentColor = Color.Gray
-            ),
-            modifier = Modifier.size(width = 50.dp, height = 30.dp),
-            shape = RoundedCornerShape(3.dp),
-            contentPadding = PaddingValues(0.dp)
-        ) {
-            Text(
-                text = "クリア",
-                fontSize = with(LocalDensity.current) { 15.dp.toSp() }
-            )
-        }
-        // 合計ボタン
-        Button(
-            onClick = { sumDialog = true },
-            colors = ButtonDefaults.buttonColors(
-                containerColor = Color.LightGray,
-                contentColor = Color.Black,
-                disabledContainerColor = Color.LightGray,
-                disabledContentColor = Color.Gray
-            ),
-            modifier = Modifier.size(width = 50.dp, height = 30.dp),
-            shape = RoundedCornerShape(3.dp),
-            contentPadding = PaddingValues(0.dp)
-        ) {
-            Text(
-                text = "合計",
-                fontSize = with(LocalDensity.current) { 15.dp.toSp() }
-            )
-        }
-    }
-    if (alertDialog) {
-        AlertDialog(
-            onDismissRequest = { alertDialog = false },
-            text = {
-                Text(text = "本当に削除しますか？")
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        StockData.stockList.clear()
-                        alertDialog = false
-                    }
-                ) {
-                    Text(text = "OK")
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { alertDialog = false }) {
-                    Text(text = "Cancel")
-                }
-            }
-        )
-    }
-    if (sumDialog) {
-        AlertDialog(
-            onDismissRequest = { sumDialog = false },
-            text = {
-                Text(text = "合計${"%,d".format(StockData.stockList.sumOf{ it.quantity })}です。")
-            },
-            confirmButton = {
-                TextButton(onClick = { sumDialog = false }) {
-                    Text(text = "OK")
-                }
-            },
-        )
-    }
-}
-
-object StockData {
-    var stockList = mutableStateListOf(
-        Stock("23:59:59", 9999, "コメントコメントコメントコメントコメント"),
-        Stock("00:00:00", 0, ""),
-        Stock("00:00:00", 0, """!"#$%&'()=~|`{}_?*+><'""")
-    )
 }

--- a/app/src/main/java/com/example/apptask/MainActivity.kt
+++ b/app/src/main/java/com/example/apptask/MainActivity.kt
@@ -61,8 +61,13 @@ private fun Preview() {
     }
 }
 
-const val min = 0
-const val max = 9999
+class Constants {
+    companion object {
+        const val STOCK_QUANTITY_MIN = 0
+        const val STOCK_QUANTITY_MAX = 9999
+        const val CLOCK_FORMAT = "hh:mm:ss"
+    }
+}
 
 data class Stock(val clock: String, val quantity: Int, val comment: String)
 

--- a/app/src/main/java/com/example/apptask/MainActivity.kt
+++ b/app/src/main/java/com/example/apptask/MainActivity.kt
@@ -33,7 +33,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             AppTaskTheme {
                 Surface(modifier = Modifier.fillMaxSize()) {
-                    ShowHome()
+                    Home()
                 }
             }
         }
@@ -53,10 +53,10 @@ class MainActivity : ComponentActivity() {
     name = "Dark Mode"
 )
 @Composable
-fun Preview() {
+private fun Preview() {
     AppTaskTheme {
         Surface(modifier = Modifier.fillMaxSize()) {
-            ShowHome()
+            Home()
         }
     }
 }
@@ -64,14 +64,14 @@ fun Preview() {
 const val min = 0
 const val max = 9999
 
-data class StockData(val whenAdded: String, val quantity: Int, val comment: String)
+data class Stock(val clock: String, val quantity: Int, val comment: String)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ShowHome() {
-    var showDialog by rememberSaveable { mutableStateOf(true) }
-    if (showDialog)
-        ShowFormDialog(setShowDialog = { showDialog = it })
+private fun Home() {
+    var canShowDialog by rememberSaveable { mutableStateOf(true) }
+    if (canShowDialog)
+        FormDialog(setShowDialog = { canShowDialog = it })
     Scaffold(
         topBar = {
             TopAppBar(
@@ -85,7 +85,7 @@ fun ShowHome() {
             )
         },
         floatingActionButton = {
-            FloatingActionButton(onClick = { showDialog = true }) {
+            FloatingActionButton(onClick = { canShowDialog = true }) {
                 Icon(Icons.Default.Add, "Floating action button")
             }
         }
@@ -93,7 +93,7 @@ fun ShowHome() {
         Column(
             modifier = Modifier.padding(innerPadding)
         ) {
-            ShowStockList()
+            StockList()
         }
     }
 }

--- a/app/src/main/java/com/example/apptask/StockList.kt
+++ b/app/src/main/java/com/example/apptask/StockList.kt
@@ -1,0 +1,53 @@
+package com.example.apptask
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ShowStockList() {
+    var isChecked by rememberSaveable { mutableStateOf(false) }
+    var lineColor = Color(0xFFe6e6fa)
+    if (isChecked) {
+        lineColor = Color(0xFF00ff00)
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(color = lineColor)
+            .clickable { isChecked = !isChecked }
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 5.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Checkbox(
+                checked = isChecked,
+                onCheckedChange = { isChecked = !isChecked }
+            )
+            Text(
+                modifier = Modifier
+                    .weight(1f),
+                text = "23:59:59 9999 Test"
+            )
+            Icon(Icons.Filled.Close, contentDescription = "Close")
+        }
+    }
+}

--- a/app/src/main/java/com/example/apptask/StockList.kt
+++ b/app/src/main/java/com/example/apptask/StockList.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun ShowStockList() {
+fun StockList() {
     var isChecked by rememberSaveable { mutableStateOf(false) }
     var lineColor = Color(0xFFe6e6fa)
     if (isChecked) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">AppTask</string>
+    <string name="form_title">アイテムを追加</string>
+    <string name="form_quantity">数量：</string>
+    <string name="form_addButton">追加</string>
+    <string name="form_placeHolder">コメントを入力</string>
 </resources>


### PR DESCRIPTION
## 対応済み
- Composableの命名を名詞にする
- `showDialog`を`canShowDialog`へ変更
- privateをつける
- `StockData`を`Stock`へ変更
- Composable内の固定の文言をstrings.xmlに定義
- 日時のフォーマットを定数化
## 未対応
- `setShowDialog`はボタン以外の操作(ダイアログ外のタップ等)にも使用されるため、`onClick〇〇Button`に変更していません。