### PR TITLE
画像管理

### DIFF
--- a/app/src/main/java/com/example/apptask/FormDialog.kt
+++ b/app/src/main/java/com/example/apptask/FormDialog.kt
@@ -69,7 +69,7 @@ fun FormDialog(
                     )
                     Icon(
                         imageVector = Icons.Filled.Close,
-                        contentDescription = stringResource(R.string.form_button_desc_close),
+                        contentDescription = stringResource(R.string.form_button_close_desc),
                         tint = colorResource(android.R.color.darker_gray),
                         modifier = Modifier.clickable { onClickClose() }
                     )

--- a/app/src/main/java/com/example/apptask/StockDetailScreen.kt
+++ b/app/src/main/java/com/example/apptask/StockDetailScreen.kt
@@ -5,7 +5,10 @@ import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -23,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -53,7 +57,7 @@ fun StockDetailScreen(
                     IconButton(onClick = { onPopToScreen((Route.StockListScreen())) }) {
                         Icon(
                             imageVector = Icons.Default.ArrowBack,
-                            contentDescription = stringResource(R.string.detail_button_desc_back)
+                            contentDescription = stringResource(R.string.detail_button_back_desc)
                         )
                     }
                 }
@@ -67,11 +71,6 @@ fun StockDetailScreen(
             Text(text = "quantity:${stock.quantity}")
             Text(text = "comment:${stock.comment}")
             ImagePicker(stock.uri)
-            Button(
-                onClick = { /*TODO*/ }
-            ) {
-                Text(text = "保存")
-            }
         }
     }
 }
@@ -85,11 +84,23 @@ fun ImagePicker(stockUri: Uri?) {
         imageUri = uri
     }
     Column {
-        Button(
-            onClick = { launcher.launch("image/*") }
-        ) {
-            Text(text = stringResource(R.string.form_button_add))
+        Row {
+            Button(
+                onClick = { launcher.launch("image/*") }
+            ) {
+                Text(text = stringResource(R.string.detail_button_add))
+            }
+            Button(
+                onClick = { /*TODO*/ }
+            ) {
+                Text(text = "保存")
+            }
         }
-        AsyncImage(model = imageUri, contentDescription = null)
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.Center
+        ) {
+            AsyncImage(model = imageUri, contentDescription = stringResource(R.string.detail_image_desc))
+        }
     }
 }

--- a/app/src/main/java/com/example/apptask/StockDetailScreen.kt
+++ b/app/src/main/java/com/example/apptask/StockDetailScreen.kt
@@ -66,15 +66,20 @@ fun StockDetailScreen(
             Text(text = "clock:${stock.clock}")
             Text(text = "quantity:${stock.quantity}")
             Text(text = "comment:${stock.comment}")
-            ImagePicker()
+            ImagePicker(stock.uri)
+            Button(
+                onClick = { /*TODO*/ }
+            ) {
+                Text(text = "保存")
+            }
         }
     }
 }
 
 @RequiresApi(Build.VERSION_CODES.P)
 @Composable
-fun ImagePicker() {
-    var imageUri: Uri? by rememberSaveable { mutableStateOf(null) }
+fun ImagePicker(stockUri: Uri?) {
+    var imageUri: Uri? by rememberSaveable { mutableStateOf(stockUri) }
     val launcher = rememberLauncherForActivityResult(contract = ActivityResultContracts.GetContent()) { uri ->
         if (uri == null) return@rememberLauncherForActivityResult
         imageUri = uri

--- a/app/src/main/java/com/example/apptask/StockList.kt
+++ b/app/src/main/java/com/example/apptask/StockList.kt
@@ -70,7 +70,7 @@ fun StockRow(
             )
             Icon(
                 imageVector = Icons.Filled.Close,
-                contentDescription = stringResource(R.string.list_button_desc_delete),
+                contentDescription = stringResource(R.string.list_button_delete_desc),
                 modifier = Modifier.clickable { onClickDelete() }
             )
         }

--- a/app/src/main/java/com/example/apptask/StockListScreen.kt
+++ b/app/src/main/java/com/example/apptask/StockListScreen.kt
@@ -73,7 +73,7 @@ fun StockListScreen(onNavigateToScreen: (Route) -> Unit) {
             FloatingActionButton(onClick = { canShowDialog = true }) {
                 Icon(
                     imageVector = Icons.Default.Add,
-                    contentDescription = stringResource(R.string.home_button_desc_add)
+                    contentDescription = stringResource(R.string.home_button_add_desc)
                 )
             }
         }
@@ -114,7 +114,7 @@ private fun Menu(onClickClear: () -> Unit, stockRowList: List<StockRowData>) {
     IconButton(onClick = { expanded = !expanded }) {
         Icon(
             imageVector = Icons.Filled.Menu,
-            contentDescription = stringResource(R.string.home_button_desc_menu)
+            contentDescription = stringResource(R.string.home_button_menu_desc)
         )
         DropdownMenu(
             expanded = expanded,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,12 +2,12 @@
     <string name="app_name">AppTask</string>
 
     <string name="home_topbar_title">リスト</string>
-    <string name="home_button_desc_menu">メニュー</string>
-    <string name="home_button_desc_add">フォームの表示</string>
+    <string name="home_button_menu_desc">メニュー</string>
+    <string name="home_button_add_desc">フォームの表示</string>
 
     <string name="form_label_title">アイテムを追加</string>
     <string name="form_label_quantity">数量：</string>
-    <string name="form_button_desc_close">閉じる</string>
+    <string name="form_button_close_desc">閉じる</string>
     <string name="form_button_plus">+</string>
     <string name="form_button_minus">-</string>
     <string name="form_button_add">追加</string>
@@ -19,7 +19,9 @@
     <string name="sum_label_message">合計 %1$d です</string>
     <string name="sum_button_ok">OK</string>
 
-    <string name="list_button_desc_delete">削除</string>
+    <string name="list_button_delete_desc">削除</string>
 
-    <string name="detail_button_desc_back">戻る</string>
+    <string name="detail_button_back_desc">戻る</string>
+    <string name="detail_button_add">画像を追加</string>
+    <string name="detail_image_desc">画像</string>
 </resources>


### PR DESCRIPTION
## チケットへのリンク
https://github.com/freemake-061/AppTask/tree/%E7%94%BB%E5%83%8F%E7%AE%A1%E7%90%86

## 概要
アプリ製作課題2

## 完了条件

- StockDetailScreenで受け取ったstockのuriをImagePickerに渡す
- 保存ボタンの追加
- 画像をボタンの下の水平方向真ん中に表示
- 他のボタンのstringResourceから借りていた"追加"をやめ"画像を追加"へ変更

## 実現方法

- ImagePickerの呼び元でstock.uriを渡す
- ImagePicker内に保存ボタン用にButtonを追記する
- Boxの中にAsyncImageを入れる
- "画像を追加"ボタン用にstring.xmlに追記する

## 動作手順

- `val stringUri = backStackEntry.arguments?.getString("stringUri")`を確認用に`val stringUri = "content://media/picker/0/com.android.providers.media.photopicker/media/1000000034"`へ変更する
- ImagePicker内でimageUriの値をprintlnを使用してログで確認する
- 確認用に変更したstringUriの値を元に戻す
- StockDetailScreenへ移動する
- 保存ボタンの表示を確認する
- "画像を追加"ボタンの表示を確認しクリックする
- フォルダから選択した画像の表示を確認する

## 動作確認結果

- imageUriに`"content://media/picker/0/com.android.providers.media.photopicker/media/1000000034"`が渡っていることを確認
- StockDetailScreenへ移動することを確認
- 保存ボタンが正しく表示されることを確認
- "画像を追加"ボタンが正しく表示されることを確認
- ボタンの下の水平方向真ん中に画像が正しく表示されることを確認

## 想定される問題点
なし

## その他
なし